### PR TITLE
fix(breaking): ACNA-1682 - HTTP/HTTPS proxy agent logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 coverage
 launch.json
 package-lock.json
+yarn.lock
 /node_modules/
 junit.xml
 test-report.html

--- a/src/ProxyFetch.js
+++ b/src/ProxyFetch.js
@@ -58,9 +58,10 @@ class ProxyFetch {
   /**
    * Returns the http.Agent used for this proxy
    *
+   * @param {string} resourceUrl an endpoint url for proxyAgent selection
    * @returns {http.Agent} a http.Agent for basic auth proxy
    */
-  proxyAgent () {
+  proxyAgent (resourceUrl) {
     const { proxyUrl, username, password, rejectUnauthorized = true } = this.authOptions
     const proxyOpts = urlToHttpOptions(proxyUrl)
 
@@ -76,7 +77,7 @@ class ProxyFetch {
       logger.warn(`proxyAgent - rejectUnauthorized is set to ${rejectUnauthorized}`)
     }
 
-    if (proxyOpts.protocol.startsWith('https')) {
+    if (resourceUrl.startsWith('https')) {
       return new HttpsProxyAgent(proxyOpts)
     } else {
       return new HttpProxyAgent(proxyOpts)
@@ -93,7 +94,7 @@ class ProxyFetch {
   async fetch (resource, options = {}) {
     return originalFetch(resource, {
       ...options,
-      agent: this.proxyAgent()
+      agent: this.proxyAgent(resource)
     })
   }
 }

--- a/src/ProxyFetch.js
+++ b/src/ProxyFetch.js
@@ -16,9 +16,38 @@ const { codes } = require('./SDKErrors')
 const HttpProxyAgent = require('http-proxy-agent')
 const HttpsProxyAgent = require('https-proxy-agent')
 const { urlToHttpOptions } = require('./utils')
-const http = require('http')
 
 /* global Response, Request */
+
+/**
+ * @private
+ *
+ * @param {string} resourceUrl an endpoint url for proxyAgent selection
+ * @param {object} authOptions an object which contains auth information
+ * @returns {http.Agent} a http.Agent for basic auth proxy
+ */
+function proxyAgent (resourceUrl, authOptions) {
+  const { proxyUrl, username, password, rejectUnauthorized = true } = authOptions
+  const proxyOpts = urlToHttpOptions(proxyUrl)
+
+  if (!proxyOpts.auth && username && password) {
+    logger.debug('username and password not set in proxy url, using credentials passed in the constructor.')
+    proxyOpts.auth = `${username}:${password}`
+  }
+
+  // the passing on of this property to the underlying implementation only works on https-proxy-agent@2.2.4
+  // this is only used for unit-tests and passed in the constructor
+  proxyOpts.rejectUnauthorized = rejectUnauthorized
+  if (rejectUnauthorized === false) {
+    logger.warn(`proxyAgent - rejectUnauthorized is set to ${rejectUnauthorized}`)
+  }
+
+  if (resourceUrl.startsWith('https')) {
+    return new HttpsProxyAgent(proxyOpts)
+  } else {
+    return new HttpProxyAgent(proxyOpts)
+  }
+}
 
 /**
  * Proxy Auth Options
@@ -56,35 +85,6 @@ class ProxyFetch {
   }
 
   /**
-   * Returns the http.Agent used for this proxy
-   *
-   * @param {string} resourceUrl an endpoint url for proxyAgent selection
-   * @returns {http.Agent} a http.Agent for basic auth proxy
-   */
-  proxyAgent (resourceUrl) {
-    const { proxyUrl, username, password, rejectUnauthorized = true } = this.authOptions
-    const proxyOpts = urlToHttpOptions(proxyUrl)
-
-    if (!proxyOpts.auth && username && password) {
-      logger.debug('username and password not set in proxy url, using credentials passed in the constructor.')
-      proxyOpts.auth = `${username}:${password}`
-    }
-
-    // the passing on of this property to the underlying implementation only works on https-proxy-agent@2.2.4
-    // this is only used for unit-tests and passed in the constructor
-    proxyOpts.rejectUnauthorized = rejectUnauthorized
-    if (rejectUnauthorized === false) {
-      logger.warn(`proxyAgent - rejectUnauthorized is set to ${rejectUnauthorized}`)
-    }
-
-    if (resourceUrl.startsWith('https')) {
-      return new HttpsProxyAgent(proxyOpts)
-    } else {
-      return new HttpProxyAgent(proxyOpts)
-    }
-  }
-
-  /**
    * Fetch function, using the configured NTLM Auth options.
    *
    * @param {string | Request} resource - the url or Request object to fetch from
@@ -94,7 +94,7 @@ class ProxyFetch {
   async fetch (resource, options = {}) {
     return originalFetch(resource, {
       ...options,
-      agent: this.proxyAgent(resource)
+      agent: proxyAgent(resource, this.authOptions)
     })
   }
 }

--- a/test/proxy.test.js
+++ b/test/proxy.test.js
@@ -110,6 +110,10 @@ describe('http proxy', () => {
 
       const testUrl = `${protocol}://localhost:${apiServerPort}/mirror?${queryString.stringify(queryObject)}`
       const response = await proxyFetch.fetch(testUrl, { headers })
+      const spy = jest.spyOn(proxyFetch, 'fetch').mockImplementation(() => testUrl)
+      const pattern = /\b^http\b/
+      expect(proxyFetch.fetch()).toMatch(new RegExp(pattern))
+      spy.mockRestore()
       expect(response.ok).toEqual(true)
       const json = await response.json()
       expect(json).toStrictEqual(queryObject)
@@ -134,6 +138,10 @@ describe('http proxy', () => {
 
       const testUrl = `${protocol}://localhost:${apiServerPort}/mirror?${queryString.stringify(queryObject)}`
       const response = await proxyFetch.fetch(testUrl, { headers })
+      const spy = jest.spyOn(proxyFetch, 'fetch').mockImplementation(() => testUrl)
+      const pattern = /\b^https\b/
+      expect(proxyFetch.fetch()).not.toMatch(new RegExp(pattern))
+      spy.mockRestore()
       expect(response.ok).toEqual(false)
       expect(response.status).toEqual(403)
     })
@@ -177,46 +185,6 @@ describe('http proxy', () => {
       }, [], 0) // retryDelay must be zero for test timings
       expect(response.ok).toEqual(false)
       expect(response.status).toEqual(502)
-    })
-  })
-
-  describe('http proxy agent test case', () => {
-    beforeAll(async () => {
-      proxyServer = await createHttpProxy({ useBasicAuth: false })
-      apiServer = await createApiServer({ port: 3000, useSsl: false })
-    })
-
-    afterAll(async () => {
-      await proxyServer.stop()
-      await apiServer.close()
-    })
-
-    test('success', async () => {
-      const apiServerAddress = apiServer.address()
-      const queryObject = { foo: 'bar' }
-
-      const testUrl = `${protocol}://localhost:${apiServerAddress.port}/mirror?${queryString.stringify(queryObject)}`
-
-      const proxyUrl = proxyServer.url
-      const proxyFetch = new ProxyFetch({ proxyUrl, rejectUnauthorized: false })
-      const spy = jest.spyOn(proxyFetch, 'fetch').mockImplementation(() => testUrl)
-      const pattern = /\b^http\b/
-      expect(proxyFetch.fetch()).toMatch(new RegExp(pattern))
-      spy.mockRestore()
-    })
-
-    test('failure', async () => {
-      const apiServerAddress = apiServer.address()
-      const queryObject = { foo: 'bar' }
-
-      const testUrl = `${protocol}://localhost:${apiServerAddress.port}/mirror?${queryString.stringify(queryObject)}`
-
-      const proxyUrl = proxyServer.url
-      const proxyFetch = new ProxyFetch({ proxyUrl, rejectUnauthorized: false })
-      const spy = jest.spyOn(proxyFetch, 'fetch').mockImplementation(() => testUrl)
-      const pattern = /\b^https\b/
-      expect(proxyFetch.fetch()).not.toMatch(new RegExp(pattern))
-      spy.mockRestore()
     })
   })
 })
@@ -289,6 +257,10 @@ describe('https proxy', () => {
 
       const testUrl = `${protocol}://localhost:${apiServerPort}/mirror?${queryString.stringify(queryObject)}`
       const response = await proxyFetch.fetch(testUrl, { headers })
+      const spy = jest.spyOn(proxyFetch, 'fetch').mockImplementation(() => testUrl)
+      const pattern = /\b^https\b/
+      expect(proxyFetch.fetch()).toMatch(new RegExp(pattern))
+      spy.mockRestore()
       expect(response.ok).toEqual(true)
       const json = await response.json()
       expect(json).toStrictEqual(queryObject)
@@ -308,6 +280,10 @@ describe('https proxy', () => {
 
       const testUrl = `${protocol}://localhost:${apiServerPort}/mirror?${queryString.stringify(queryObject)}`
       const response = await proxyFetch.fetch(testUrl, { headers })
+      const spy = jest.spyOn(proxyFetch, 'fetch').mockImplementation(() => testUrl)
+      const pattern = /\b^http\b/
+      expect(proxyFetch.fetch()).not.toMatch(new RegExp(pattern))
+      spy.mockRestore()
       expect(response.ok).toEqual(false)
       expect(response.status).toEqual(403)
     })
@@ -351,46 +327,6 @@ describe('https proxy', () => {
       }, [], 0) // retryDelay must be zero for test timings
       expect(response.ok).toEqual(false)
       expect(response.status).toEqual(502)
-    })
-  })
-
-  describe('https proxy agent test case', () => {
-    beforeAll(async () => {
-      proxyServer = await createHttpProxy({ useBasicAuth: false })
-      apiServer = await createApiServer({ port: 3000, useSsl: false })
-    })
-
-    afterAll(async () => {
-      await proxyServer.stop()
-      await apiServer.close()
-    })
-
-    test('success', async () => {
-      const apiServerAddress = apiServer.address()
-      const queryObject = { foo: 'bar' }
-
-      const testUrl = `${protocol}://localhost:${apiServerAddress.port}/mirror?${queryString.stringify(queryObject)}`
-
-      const proxyUrl = proxyServer.url
-      const proxyFetch = new ProxyFetch({ proxyUrl, rejectUnauthorized: false })
-      const spy = jest.spyOn(proxyFetch, 'fetch').mockImplementation(() => testUrl)
-      const pattern = /\b^https\b/
-      expect(proxyFetch.fetch()).toMatch(new RegExp(pattern))
-      spy.mockRestore()
-    })
-
-    test('failure', async () => {
-      const apiServerAddress = apiServer.address()
-      const queryObject = { foo: 'bar' }
-
-      const testUrl = `${protocol}://localhost:${apiServerAddress.port}/mirror?${queryString.stringify(queryObject)}`
-
-      const proxyUrl = proxyServer.url
-      const proxyFetch = new ProxyFetch({ proxyUrl, rejectUnauthorized: false })
-      const spy = jest.spyOn(proxyFetch, 'fetch').mockImplementation(() => testUrl)
-      const pattern = /\b^http\b/
-      expect(proxyFetch.fetch()).not.toMatch(new RegExp(pattern))
-      spy.mockRestore()
     })
   })
 })

--- a/test/proxy.test.js
+++ b/test/proxy.test.js
@@ -179,6 +179,46 @@ describe('http proxy', () => {
       expect(response.status).toEqual(502)
     })
   })
+
+  describe('http proxy agent test case', () => {
+    beforeAll(async () => {
+      proxyServer = await createHttpProxy({ useBasicAuth: false })
+      apiServer = await createApiServer({ port: 3000, useSsl: false })
+    })
+
+    afterAll(async () => {
+      await proxyServer.stop()
+      await apiServer.close()
+    })
+
+    test('success', async () => {
+      const apiServerAddress = apiServer.address()
+      const queryObject = { foo: 'bar' }
+
+      const testUrl = `${protocol}://localhost:${apiServerAddress.port}/mirror?${queryString.stringify(queryObject)}`
+
+      const proxyUrl = proxyServer.url
+      const proxyFetch = new ProxyFetch({ proxyUrl, rejectUnauthorized: false })
+      const spy = jest.spyOn(proxyFetch, 'fetch').mockImplementation(() => testUrl)
+      const pattern = /\b^http\b/
+      expect(proxyFetch.fetch()).toMatch(new RegExp(pattern))
+      spy.mockRestore()
+    })
+
+    test('failure', async () => {
+      const apiServerAddress = apiServer.address()
+      const queryObject = { foo: 'bar' }
+
+      const testUrl = `${protocol}://localhost:${apiServerAddress.port}/mirror?${queryString.stringify(queryObject)}`
+
+      const proxyUrl = proxyServer.url
+      const proxyFetch = new ProxyFetch({ proxyUrl, rejectUnauthorized: false })
+      const spy = jest.spyOn(proxyFetch, 'fetch').mockImplementation(() => testUrl)
+      const pattern = /\b^https\b/
+      expect(proxyFetch.fetch()).not.toMatch(new RegExp(pattern))
+      spy.mockRestore()
+    })
+  })
 })
 
 describe('https proxy', () => {
@@ -311,6 +351,46 @@ describe('https proxy', () => {
       }, [], 0) // retryDelay must be zero for test timings
       expect(response.ok).toEqual(false)
       expect(response.status).toEqual(502)
+    })
+  })
+
+  describe('https proxy agent test case', () => {
+    beforeAll(async () => {
+      proxyServer = await createHttpProxy({ useBasicAuth: false })
+      apiServer = await createApiServer({ port: 3000, useSsl: false })
+    })
+
+    afterAll(async () => {
+      await proxyServer.stop()
+      await apiServer.close()
+    })
+
+    test('success', async () => {
+      const apiServerAddress = apiServer.address()
+      const queryObject = { foo: 'bar' }
+
+      const testUrl = `${protocol}://localhost:${apiServerAddress.port}/mirror?${queryString.stringify(queryObject)}`
+
+      const proxyUrl = proxyServer.url
+      const proxyFetch = new ProxyFetch({ proxyUrl, rejectUnauthorized: false })
+      const spy = jest.spyOn(proxyFetch, 'fetch').mockImplementation(() => testUrl)
+      const pattern = /\b^https\b/
+      expect(proxyFetch.fetch()).toMatch(new RegExp(pattern))
+      spy.mockRestore()
+    })
+
+    test('failure', async () => {
+      const apiServerAddress = apiServer.address()
+      const queryObject = { foo: 'bar' }
+
+      const testUrl = `${protocol}://localhost:${apiServerAddress.port}/mirror?${queryString.stringify(queryObject)}`
+
+      const proxyUrl = proxyServer.url
+      const proxyFetch = new ProxyFetch({ proxyUrl, rejectUnauthorized: false })
+      const spy = jest.spyOn(proxyFetch, 'fetch').mockImplementation(() => testUrl)
+      const pattern = /\b^http\b/
+      expect(proxyFetch.fetch()).not.toMatch(new RegExp(pattern))
+      spy.mockRestore()
     })
   })
 })


### PR DESCRIPTION
# [ACNA-1682](https://jira.corp.adobe.com/browse/ACNA-1682) | HTTP/HTTPS Proxy Agent Logic

## Description

https://github.com/adobe/aio-lib-core-networking/blob/b8dca7b8c0ab6c91b5fad0343a84635f1690ecb0/src/ProxyFetch.js#L79-L83

This bases whether to use HTTP/HTTPS proxy based on what the proxy protocol is, however this logic is wrong, it should be based on what the end point protocol is:

| Type            | Proxy | Server |
|-----------------|-------|--------|
| HttpProxyAgent  | HTTP  | HTTP   |
| HttpProxyAgent  | HTTPS | HTTP   |
| HttpsProxyAgent | HTTP  | HTTPS  |
| HttpsProxyAgent | HTTPS | HTTPS  |

As a result, using an http proxy and connecting to an https endpoint causes the logic to pick HttpProxyAgent which then returns an error from the server as we are trying to connect to it via non HTTPS methods

Fixes #16

## Related Issue

https://jira.corp.adobe.com/browse/ACNA-1682

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

- Code has been test on local machine
- Unit tests are passing

## Screenshots (if appropriate):
<img width="1036" alt="Screenshot 2022-06-08 at 1 46 47 PM" src="https://user-images.githubusercontent.com/19944275/172567515-aa245f2e-2759-42d0-b2c8-ce02c64788ad.png">

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
