### PR TITLE
fix: proxy usernames & passwords with special characters. align with curl 

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -77,7 +77,7 @@ function urlToHttpOptions (aUrl) {
   }
 
   if (username && password) {
-    options.auth = `${username}:${password}`
+    options.auth = `${decodeURI(username)}:${decodeURI(password)}`
   }
   return options
 }

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -57,6 +57,26 @@ test('url test (basic auth)', () => {
   })
 })
 
+/*
+  Proxy username and password: special character support
+  Ensure that the special character (here: encoded backslash in the username) is decoded in the 'auth' property.
+  See curl (e.g., with verbose output) for reference
+*/
+test('url test (basic auth) with special character in username', () => {
+  const url = 'http://domain%5Cadmin:secret@example.com/mypath/?query=foo'
+  expect(urlToHttpOptions(url)).toStrictEqual({
+    hash: '',
+    hostname: 'example.com',
+    href: 'http://domain%5Cadmin:secret@example.com/mypath/?query=foo',
+    path: undefined,
+    pathname: '/mypath/',
+    port: '',
+    protocol: 'http:',
+    search: '?query=foo',
+    auth: 'domain\\admin:secret'
+  })
+})
+
 describe('createFetch', () => {
   const mockProxyFetchFetch = jest.fn()
 


### PR DESCRIPTION
fixes #20

BREAKING CHANGE: URL-decoding proxy username and proxy pw may break existing setups

<!--- Provide a general summary of your changes in the Title above -->

## Description

While special characters in proxy user names and passwords can be URL-encoded / percent-encoded, their values must be URL-decoded internally before being further processed, i.e., before generating the Base64-encoded request header

<!--- Describe your changes in detail -->

## Related Issue

Fixes #20 

## Motivation and Context

Customer cannot use the technical proxy user for aio that works fine with curl

## How Has This Been Tested?

See details in https://github.com/adobe/aio-lib-core-networking/issues/20
Local squid setup (proxy server). Tests outgoing calls through the proxy using curl and aio as comparison.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
