### PR TITLE
feat: add retry-after header support

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ with defaults set to max of 3 retries and initial Delay as 100ms</p>
 <dt><a href="#createFetch">createFetch([proxyAuthOptions])</a> ⇒ <code>function</code></dt>
 <dd><p>Return the appropriate Fetch function depending on proxy settings.</p>
 </dd>
+<dt><a href="#parseRetryAfterHeader">parseRetryAfterHeader(header)</a> ⇒ <code>number</code></dt>
+<dd><p>Parse the Retry-After header
+Spec: <a href="https://tools.ietf.org/html/rfc7231#section-7.1.3">https://tools.ietf.org/html/rfc7231#section-7.1.3</a></p>
+</dd>
 </dl>
 
 ## Typedefs
@@ -141,7 +145,6 @@ This provides a wrapper for fetch that facilitates proxy auth authorization.
 
 * [ProxyFetch](#ProxyFetch)
     * [new ProxyFetch(authOptions)](#new_ProxyFetch_new)
-    * [.proxyAgent()](#ProxyFetch+proxyAgent) ⇒ <code>http.Agent</code>
     * [.fetch(resource, options)](#ProxyFetch+fetch) ⇒ <code>Promise.&lt;Response&gt;</code>
 
 <a name="new_ProxyFetch_new"></a>
@@ -154,13 +157,6 @@ Initialize this class with Proxy auth options
 | --- | --- | --- |
 | authOptions | [<code>ProxyAuthOptions</code>](#ProxyAuthOptions) | the auth options to connect with |
 
-<a name="ProxyFetch+proxyAgent"></a>
-
-### proxyFetch.proxyAgent() ⇒ <code>http.Agent</code>
-Returns the http.Agent used for this proxy
-
-**Kind**: instance method of [<code>ProxyFetch</code>](#ProxyFetch)  
-**Returns**: <code>http.Agent</code> - a http.Agent for basic auth proxy  
 <a name="ProxyFetch+fetch"></a>
 
 ### proxyFetch.fetch(resource, options) ⇒ <code>Promise.&lt;Response&gt;</code>
@@ -185,6 +181,19 @@ Return the appropriate Fetch function depending on proxy settings.
 | Param | Type | Description |
 | --- | --- | --- |
 | [proxyAuthOptions] | [<code>ProxyAuthOptions</code>](#ProxyAuthOptions) | the proxy auth options |
+
+<a name="parseRetryAfterHeader"></a>
+
+## parseRetryAfterHeader(header) ⇒ <code>number</code>
+Parse the Retry-After header
+Spec: [https://tools.ietf.org/html/rfc7231#section-7.1.3](https://tools.ietf.org/html/rfc7231#section-7.1.3)
+
+**Kind**: global function  
+**Returns**: <code>number</code> - Number of milliseconds to sleep until the next call to getEventsFromJournal  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| header | <code>string</code> | Retry-After header value |
 
 <a name="RetryOptions"></a>
 

--- a/src/HttpExponentialBackoff.js
+++ b/src/HttpExponentialBackoff.js
@@ -140,8 +140,8 @@ class HttpExponentialBackoff {
   __getRetryDelayWithRetryAfterHeader (initialDelayInMillis) {
     return (attempt, error, response) => {
       const retryAfter = response.headers.get('Retry-After')
-      if (retryAfter != null) {
-        const timeToWait = parseRetryAfterHeader(retryAfter)
+      const timeToWait = parseRetryAfterHeader(retryAfter)
+      if (!isNaN(timeToWait)) {
         logger.debug(`Request will be retried after ${timeToWait} ms`)
         return timeToWait
       }

--- a/src/HttpExponentialBackoff.js
+++ b/src/HttpExponentialBackoff.js
@@ -141,7 +141,9 @@ class HttpExponentialBackoff {
     return (attempt, error, response) => {
       const retryAfter = response.headers.get('Retry-After')
       if (retryAfter != null) {
-        return parseRetryAfterHeader(retryAfter)
+        const timeToWait = parseRetryAfterHeader(retryAfter)
+        logger.debug(`Request will be retried after ${timeToWait} ms`)
+        return timeToWait
       }
       return this.__getRetryDelay(initialDelayInMillis)(attempt, error, response)
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -82,7 +82,23 @@ function urlToHttpOptions (aUrl) {
   return options
 }
 
+/**
+ * Parse the Retry-After header
+ * Spec: {@link https://tools.ietf.org/html/rfc7231#section-7.1.3}
+ *
+ * @param {string} header Retry-After header value
+ * @returns {number} Number of milliseconds to sleep until the next call to getEventsFromJournal
+ */
+function parseRetryAfterHeader (header) {
+  if (header.match(/^[0-9]+$/)) {
+    return parseInt(header, 10) * 1000
+  } else {
+    return Math.max(0, Date.parse(header) - Date.now())
+  }
+}
+
 module.exports = {
   urlToHttpOptions,
-  createFetch
+  createFetch,
+  parseRetryAfterHeader
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -90,6 +90,7 @@ function urlToHttpOptions (aUrl) {
  * @returns {number} Number of milliseconds to sleep until the next call to getEventsFromJournal
  */
 function parseRetryAfterHeader (header) {
+  logger.debug('Parsing Retry-After header')
   if (header.match(/^[0-9]+$/)) {
     return parseInt(header, 10) * 1000
   } else {

--- a/src/utils.js
+++ b/src/utils.js
@@ -90,7 +90,6 @@ function urlToHttpOptions (aUrl) {
  * @returns {number} Number of milliseconds to sleep until the next call to getEventsFromJournal
  */
 function parseRetryAfterHeader (header) {
-  logger.debug('Parsing Retry-After header')
   if (header.match(/^[0-9]+$/)) {
     return parseInt(header, 10) * 1000
   } else {

--- a/src/utils.js
+++ b/src/utils.js
@@ -90,11 +90,21 @@ function urlToHttpOptions (aUrl) {
  * @returns {number} Number of milliseconds to sleep until the next call to getEventsFromJournal
  */
 function parseRetryAfterHeader (header) {
-  if (header.match(/^[0-9]+$/)) {
-    return parseInt(header, 10) * 1000
-  } else {
-    return Math.max(0, Date.parse(header) - Date.now())
+  if (header == null) {
+    return NaN
   }
+  if (header.match(/^[0-9]+$/)) {
+    const delta = parseInt(header, 10) * 1000
+    return delta <= 0 ? NaN : delta
+  }
+  if (header.match(/^-[0-9]+$/)) {
+    return NaN
+  }
+  const dateMs = Date.parse(header)
+  const delta = dateMs - Date.now()
+  return isNaN(delta) || delta <= 0
+    ? NaN
+    : delta
 }
 
 module.exports = {

--- a/test/HttpExponentialBackoff.test.js
+++ b/test/HttpExponentialBackoff.test.js
@@ -44,9 +44,7 @@ function __testRetryDelayHelper (initialDelay) {
   return jest.fn().mockImplementation(function (attempt, error, response) {
     const retryAfter = response.headers.get('Retry-After')
     if (retryAfter != null) {
-      const a = parseRetryAfterHeader(retryAfter)
-      console.log(a)
-      return a
+      return parseRetryAfterHeader(retryAfter)
     }
     return attempt * initialDelay// 1000, 2000, 4000
   })

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -128,9 +128,21 @@ describe('createFetch', () => {
 })
 
 describe('parseRetryAfterHeader', () => {
-  test('numeric retry-after header', () => {
+  test('null retry after', () => {
+    const header = 'null'
+    expect(parseRetryAfterHeader(header)).toEqual(NaN)
+  })
+  test('positive integer retry-after header', () => {
     const header = '23'
     expect(parseRetryAfterHeader(header)).toEqual(23000)
+  })
+  test('negative integer retry-after header', () => {
+    const header = '-23'
+    expect(parseRetryAfterHeader(header)).toEqual(NaN)
+  })
+  test('retry-after header is 0', () => {
+    const header = '0'
+    expect(parseRetryAfterHeader(header)).toEqual(NaN)
   })
   test('date retry-after header', () => {
     const spy = jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('Mon, 13 Feb 2023 23:59:59 GMT'))
@@ -141,7 +153,11 @@ describe('parseRetryAfterHeader', () => {
   test('date retry-after header older than now', () => {
     const spy = jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('Tue, 14 Feb 2023 00:00:00 GMT'))
     const header = 'Mon, 13 Feb 2023 23:59:59 GMT'
-    expect(parseRetryAfterHeader(header)).toEqual(0)
+    expect(parseRetryAfterHeader(header)).toEqual(NaN)
     expect(spy).toHaveBeenCalled()
+  })
+  test('invalid retry-after header', () => {
+    const header = 'not::a::date'
+    expect(parseRetryAfterHeader(header)).toEqual(NaN)
   })
 })

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -9,7 +9,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const { urlToHttpOptions, createFetch } = require('../src/utils')
+const { urlToHttpOptions, createFetch, parseRetryAfterHeader } = require('../src/utils')
 const { ProxyFetch } = require('../src/index')
 const { getProxyForUrl } = require('proxy-from-env')
 
@@ -21,6 +21,7 @@ jest.mock('node-fetch')
 test('exports', () => {
   expect(typeof urlToHttpOptions).toEqual('function')
   expect(typeof createFetch).toEqual('function')
+  expect(typeof parseRetryAfterHeader).toEqual('function')
 })
 
 test('url test (undefined)', () => {
@@ -123,5 +124,24 @@ describe('createFetch', () => {
     expect(getProxyForUrl).toHaveBeenCalledWith(testUrl)
     expect(response.body.toString()).toEqual(body)
     expect(response.status).toEqual(result.status)
+  })
+})
+
+describe('parseRetryAfterHeader', () => {
+  test('numeric retry-after header', () => {
+    const header = '23'
+    expect(parseRetryAfterHeader(header)).toEqual(23000)
+  })
+  test('date retry-after header', () => {
+    const spy = jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('Mon, 13 Feb 2023 23:59:59 GMT'))
+    const header = 'Tue, 14 Feb 2023 00:00:00 GMT'
+    expect(parseRetryAfterHeader(header)).toEqual(1000)
+    expect(spy).toHaveBeenCalled()
+  })
+  test('date retry-after header older than now', () => {
+    const spy = jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('Tue, 14 Feb 2023 00:00:00 GMT'))
+    const header = 'Mon, 13 Feb 2023 23:59:59 GMT'
+    expect(parseRetryAfterHeader(header)).toEqual(0)
+    expect(spy).toHaveBeenCalled()
   })
 })

--- a/types.d.ts
+++ b/types.d.ts
@@ -46,11 +46,6 @@ declare type ProxyAuthOptions = {
 declare class ProxyFetch {
     constructor(authOptions: ProxyAuthOptions);
     /**
-     * Returns the http.Agent used for this proxy
-     * @returns a http.Agent for basic auth proxy
-     */
-    proxyAgent(): http.Agent;
-    /**
      * Fetch function, using the configured NTLM Auth options.
      * @param resource - the url or Request object to fetch from
      * @param options - the fetch options
@@ -65,4 +60,12 @@ declare class ProxyFetch {
  * @returns the Fetch API function
  */
 declare function createFetch(proxyAuthOptions?: ProxyAuthOptions): (...params: any[]) => any;
+
+/**
+ * Parse the Retry-After header
+ * Spec: {@link https://tools.ietf.org/html/rfc7231#section-7.1.3}
+ * @param header - Retry-After header value
+ * @returns Number of milliseconds to sleep until the next call to getEventsFromJournal
+ */
+declare function parseRetryAfterHeader(header: string): number;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Extend retries to 429 by default
- Support parsing of retry-after header and use the time specified there when available instead of the exponential backoff strategy
- Add tests to cover the new features

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

This feature is used to better handle retries.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
