### PR TITLE
fix: resourceUrl.startsWith error, proxy agent should only handle strings

### DIFF
--- a/src/ProxyFetch.js
+++ b/src/ProxyFetch.js
@@ -46,6 +46,10 @@ class PatchedHttpsProxyAgent extends HttpsProxyAgent {
  * @returns {http.Agent} a http.Agent for basic auth proxy
  */
 function proxyAgent (resourceUrl, proxyAuthOptions) {
+  if (typeof resourceUrl !== 'string') {
+    throw new codes.ERROR_PROXY_FETCH_INITIALIZATION_TYPE({ sdkDetails: { resourceUrl }, messageValues: 'resourceUrl must be of type string' })
+  }
+
   const { proxyUrl, username, password, rejectUnauthorized = true } = proxyAuthOptions
   const proxyOpts = urlToHttpOptions(proxyUrl)
 

--- a/src/SDKErrors.js
+++ b/src/SDKErrors.js
@@ -49,3 +49,4 @@ module.exports = {
 
 // Define your error codes with the wrapper
 E('ERROR_PROXY_FETCH_INITIALIZATION', 'Proxy fetch initialization error(s). Missing arguments: %s')
+E('ERROR_PROXY_FETCH_INITIALIZATION_TYPE', 'Proxy fetch initialization error(s). Arguments are the wrong type: %s')

--- a/test/proxy.test.js
+++ b/test/proxy.test.js
@@ -78,6 +78,20 @@ describe('http proxy', () => {
       expect(response.ok).toEqual(false)
       expect(response.status).toEqual(502)
     })
+
+    test('failure due to passing URL object as resourceUrl', async () => {
+      // connect to non-existent server port
+      const testUrl = new URL(`${protocol}://localhost:${portNotInUse}/mirror/?foo=bar`)
+
+      const proxyUrl = proxyServer.url
+      const proxyFetch = new ProxyFetch({ proxyUrl, rejectUnauthorized: false })
+
+      const err = new codes.ERROR_PROXY_FETCH_INITIALIZATION_TYPE({
+        sdkDetails: {},
+        messageValues: 'resourceUrl must be of type string'
+      })
+      await expect(proxyFetch.fetch(testUrl)).rejects.toThrow(err)
+    })
   })
 
   describe('basic auth', () => {


### PR DESCRIPTION
Accompanying PR: https://github.com/adobe/aio-lib-core-tvm/pull/120

Throw a useful error if caller of the library tries to pass a URL object when using a proxy. Needs to be a string