### PR TITLE
fix: ACNA-4162 - add constructor options to set log level and logRetryAfterSeconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Creates an instance of HttpExponentialBackoff
 | --- | --- | --- |
 | [options] | <code>object</code> | configuration options |
 | [options.logLevel] | <code>string</code> | the log level to use (default: process.env.LOG_LEVEL or 'info') |
+| [options.logRetryAfterSeconds] | <code>number</code> | the number of seconds after which to log a warning if the Retry-After header is greater than the number of seconds. Set to 0 to disable. |
 
 <a name="HttpExponentialBackoff+exponentialBackoff"></a>
 
@@ -176,7 +177,7 @@ Initialize this class with Proxy auth options
 <a name="ProxyFetch+fetch"></a>
 
 ### proxyFetch.fetch(resource, options) ⇒ <code>Promise.&lt;Response&gt;</code>
-Fetch function, using the configured NTLM Auth options.
+Fetch function, using the configured fetch options, and proxy options (set in the constructor).
 
 **Kind**: instance method of [<code>ProxyFetch</code>](#ProxyFetch)  
 **Returns**: <code>Promise.&lt;Response&gt;</code> - Promise object representing the http response  

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ with defaults set to max of 3 retries and initial Delay as 100ms</p>
 ## Functions
 
 <dl>
-<dt><a href="#createFetch">createFetch([proxyAuthOptions])</a> ⇒ <code>function</code></dt>
+<dt><a href="#createFetch">createFetch([proxyOptions])</a> ⇒ <code>function</code></dt>
 <dd><p>Return the appropriate Fetch function depending on proxy settings.</p>
 </dd>
 <dt><a href="#parseRetryAfterHeader">parseRetryAfterHeader(header)</a> ⇒ <code>number</code></dt>
@@ -106,7 +106,7 @@ Spec: <a href="https://tools.ietf.org/html/rfc7231#section-7.1.3">https://tools.
 <dt><a href="#RetryOptions">RetryOptions</a> : <code>object</code></dt>
 <dd><p>Fetch Retry Options</p>
 </dd>
-<dt><a href="#ProxyAuthOptions">ProxyAuthOptions</a> : <code>object</code></dt>
+<dt><a href="#ProxyOptions">ProxyOptions</a> : <code>object</code></dt>
 <dd><p>Proxy Auth Options</p>
 </dd>
 </dl>
@@ -119,6 +119,22 @@ The retries use exponential backoff strategy
 with defaults set to max of 3 retries and initial Delay as 100ms
 
 **Kind**: global class  
+
+* [HttpExponentialBackoff](#HttpExponentialBackoff)
+    * [new HttpExponentialBackoff([options])](#new_HttpExponentialBackoff_new)
+    * [.exponentialBackoff(url, requestOptions, [retryOptions], [retryOn], [retryDelay])](#HttpExponentialBackoff+exponentialBackoff) ⇒ <code>Promise.&lt;Response&gt;</code>
+
+<a name="new_HttpExponentialBackoff_new"></a>
+
+### new HttpExponentialBackoff([options])
+Creates an instance of HttpExponentialBackoff
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| [options] | <code>object</code> | configuration options |
+| [options.logLevel] | <code>string</code> | the log level to use (default: process.env.LOG_LEVEL or 'info') |
+
 <a name="HttpExponentialBackoff+exponentialBackoff"></a>
 
 ### httpExponentialBackoff.exponentialBackoff(url, requestOptions, [retryOptions], [retryOn], [retryDelay]) ⇒ <code>Promise.&lt;Response&gt;</code>
@@ -144,18 +160,18 @@ This provides a wrapper for fetch that facilitates proxy auth authorization.
 **Kind**: global class  
 
 * [ProxyFetch](#ProxyFetch)
-    * [new ProxyFetch(proxyAuthOptions)](#new_ProxyFetch_new)
+    * [new ProxyFetch(proxyOptions)](#new_ProxyFetch_new)
     * [.fetch(resource, options)](#ProxyFetch+fetch) ⇒ <code>Promise.&lt;Response&gt;</code>
 
 <a name="new_ProxyFetch_new"></a>
 
-### new ProxyFetch(proxyAuthOptions)
+### new ProxyFetch(proxyOptions)
 Initialize this class with Proxy auth options
 
 
 | Param | Type | Description |
 | --- | --- | --- |
-| proxyAuthOptions | [<code>ProxyAuthOptions</code>](#ProxyAuthOptions) | the auth options to connect with |
+| proxyOptions | [<code>ProxyOptions</code>](#ProxyOptions) | the auth options to connect with |
 
 <a name="ProxyFetch+fetch"></a>
 
@@ -172,7 +188,7 @@ Fetch function, using the configured NTLM Auth options.
 
 <a name="createFetch"></a>
 
-## createFetch([proxyAuthOptions]) ⇒ <code>function</code>
+## createFetch([proxyOptions]) ⇒ <code>function</code>
 Return the appropriate Fetch function depending on proxy settings.
 
 **Kind**: global function  
@@ -180,7 +196,7 @@ Return the appropriate Fetch function depending on proxy settings.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| [proxyAuthOptions] | [<code>ProxyAuthOptions</code>](#ProxyAuthOptions) | the proxy auth options |
+| [proxyOptions] | [<code>ProxyOptions</code>](#ProxyOptions) | the proxy options |
 
 <a name="parseRetryAfterHeader"></a>
 
@@ -207,11 +223,11 @@ Fetch Retry Options
 | --- | --- | --- |
 | maxRetries | <code>number</code> | the maximum number of retries to try (default:3) |
 | initialDelayInMillis | <code>number</code> | the initial delay in milliseconds (default:100ms) |
-| proxy | [<code>ProxyAuthOptions</code>](#ProxyAuthOptions) | the (optional) proxy auth options |
+| proxy | [<code>ProxyOptions</code>](#ProxyOptions) | the (optional) proxy auth options |
 
-<a name="ProxyAuthOptions"></a>
+<a name="ProxyOptions"></a>
 
-## ProxyAuthOptions : <code>object</code>
+## ProxyOptions : <code>object</code>
 Proxy Auth Options
 
 **Kind**: global typedef  
@@ -223,6 +239,7 @@ Proxy Auth Options
 | [username] | <code>string</code> | the username for basic auth |
 | [password] | <code>string</code> | the password for basic auth |
 | rejectUnauthorized | <code>boolean</code> | set to false to not reject unauthorized server certs |
+| [logLevel] | <code>string</code> | the log level to use (default: process.env.LOG_LEVEL or 'info') |
 
 ### Debug Logs
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -15,29 +15,29 @@ const { getProxyForUrl } = require('proxy-from-env')
 const loggerNamespace = '@adobe/aio-lib-core-networking/utils'
 const logger = require('@adobe/aio-lib-core-logging')(loggerNamespace, { level: process.env.LOG_LEVEL })
 
-/* global ProxyAuthOptions */
+/* global ProxyOptions */
 
 /**
  * Return the appropriate Fetch function depending on proxy settings.
  *
- * @param {ProxyAuthOptions} [proxyAuthOptions] the proxy auth options
+ * @param {ProxyOptions} [proxyOptions] the proxy options
  * @returns {Function} the Fetch API function
  */
-function createFetch (proxyAuthOptions) {
+function createFetch (proxyOptions) {
   const fn = async (resource, options) => {
-    // proxyAuthOptions as a parameter will override any proxy env vars
-    if (!proxyAuthOptions) {
+    // proxyOptions as a parameter will override any proxy env vars
+    if (!proxyOptions) {
       const proxyUrl = getProxyForUrl(resource)
       if (proxyUrl) {
-        proxyAuthOptions = { proxyUrl }
+        proxyOptions = { proxyUrl }
       }
     }
 
-    if (proxyAuthOptions) {
-      logger.debug(`createFetch: proxy url found ${proxyAuthOptions.proxyUrl} for url ${resource}`)
+    if (proxyOptions) {
+      logger.debug(`createFetch: proxy url found ${proxyOptions.proxyUrl} for url ${resource}`)
       // in this closure: for fetch-retry, if we don't require it dynamically here, ProxyFetch will be an empty object
       const ProxyFetch = require('./ProxyFetch')
-      const proxyFetch = new ProxyFetch(proxyAuthOptions)
+      const proxyFetch = new ProxyFetch(proxyOptions)
       return proxyFetch.fetch(resource, options)
     } else {
       logger.debug('createFetch: proxy url not found, using plain fetch')

--- a/types.d.ts
+++ b/types.d.ts
@@ -14,10 +14,12 @@ declare type RetryOptions = {
  * Creates an instance of HttpExponentialBackoff
  * @param [options] - configuration options
  * @param [options.logLevel] - the log level to use (default: process.env.LOG_LEVEL or 'info')
+ * @param [options.logRetryAfterSeconds] - the number of seconds after which to log a warning if the Retry-After header is greater than the number of seconds. Set to 0 to disable.
  */
 declare class HttpExponentialBackoff {
     constructor(options?: {
         logLevel?: string;
+        logRetryAfterSeconds?: number;
     });
     /**
      * This function will retry connecting to a url end-point, with
@@ -55,7 +57,7 @@ declare type ProxyOptions = {
 declare class ProxyFetch {
     constructor(proxyOptions: ProxyOptions);
     /**
-     * Fetch function, using the configured NTLM Auth options.
+     * Fetch function, using the configured fetch options, and proxy options (set in the constructor).
      * @param resource - the url or Request object to fetch from
      * @param options - the fetch options
      * @returns Promise object representing the http response

--- a/types.d.ts
+++ b/types.d.ts
@@ -7,15 +7,18 @@
 declare type RetryOptions = {
     maxRetries: number;
     initialDelayInMillis: number;
-    proxy: ProxyAuthOptions;
+    proxy: ProxyOptions;
 };
 
 /**
- * This class provides methods to implement fetch with retries.
- * The retries use exponential backoff strategy
- * with defaults set to max of 3 retries and initial Delay as 100ms
+ * Creates an instance of HttpExponentialBackoff
+ * @param [options] - configuration options
+ * @param [options.logLevel] - the log level to use (default: process.env.LOG_LEVEL or 'info')
  */
 declare class HttpExponentialBackoff {
+    constructor(options?: {
+        logLevel?: string;
+    });
     /**
      * This function will retry connecting to a url end-point, with
      * exponential backoff. Returns a Promise.
@@ -35,20 +38,22 @@ declare class HttpExponentialBackoff {
  * @property [username] - the username for basic auth
  * @property [password] - the password for basic auth
  * @property rejectUnauthorized - set to false to not reject unauthorized server certs
+ * @property [logLevel] - the log level to use (default: process.env.LOG_LEVEL or 'info')
  */
-declare type ProxyAuthOptions = {
+declare type ProxyOptions = {
     proxyUrl: string;
     username?: string;
     password?: string;
     rejectUnauthorized: boolean;
+    logLevel?: string;
 };
 
 /**
  * Initialize this class with Proxy auth options
- * @param proxyAuthOptions - the auth options to connect with
+ * @param proxyOptions - the auth options to connect with
  */
 declare class ProxyFetch {
-    constructor(proxyAuthOptions: ProxyAuthOptions);
+    constructor(proxyOptions: ProxyOptions);
     /**
      * Fetch function, using the configured NTLM Auth options.
      * @param resource - the url or Request object to fetch from
@@ -60,10 +65,10 @@ declare class ProxyFetch {
 
 /**
  * Return the appropriate Fetch function depending on proxy settings.
- * @param [proxyAuthOptions] - the proxy auth options
+ * @param [proxyOptions] - the proxy options
  * @returns the Fetch API function
  */
-declare function createFetch(proxyAuthOptions?: ProxyAuthOptions): (...params: any[]) => any;
+declare function createFetch(proxyOptions?: ProxyOptions): (...params: any[]) => any;
 
 /**
  * Parse the Retry-After header


### PR DESCRIPTION
Closes #101 
Closes #99

Related: https://github.com/adobe/aio-lib-core-networking/pull/102

## Description

Currently the log level can be set by setting the env var `LOG_LEVEL` only which may be less intuitive to set in serverless environments. Also a logRetryAfter setting is added - the number of seconds after which to log a warning if the Retry-After header is greater than the number of seconds. Set to 0 to disable.

Allow dependent callers of this library to set the log level via their respective constructors - for example @adobe/aio-lib-state library.

## Related Issue

See #101 

## How Has This Been Tested?

- npm test

- used this code:
```javascript
const { createFetch, HttpExponentialBackoff } = require('@adobe/aio-lib-core-networking'); // from the branch code
const LOG_LEVEL = 'debug'; // set to 'info' not to see any retries, etc

const proxyFetch = createFetch({ 
    proxyUrl: 'http://localhost:8888',
    logLevel: LOG_LEVEL
})

const httpExponentialBackoff = new HttpExponentialBackoff({
    maxRetries: 3,
    initialDelay: 1000,
    maxDelay: 10000,
    logLevel: LOG_LEVEL,
});

async function main() {
    const response = await proxyFetch('https://www.google.com');
    console.log('ProxyFetch response: ', response.status);
    // this should fail, and retry, and if LOG_LEVEL is debug, it should show debug logs
    const response2 = await httpExponentialBackoff.exponentialBackoff('https://somegibberishurl.com', {});
    console.log('HttpExponentialBackoff response: ', response2.status);
}

main();
```

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
